### PR TITLE
Re-order .env file load order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2019-02-05
+Small bug fix. We changed the load order of .env.personal and .env. .env.personal should
+override .env.
+
+### Changed
+- .env.personal now overrides .env
+
 ## [2.0.0] - 2019-02-04
 Lots of dev experience, error/loading state improvements and performance improvements.
 In addition, we now support newer versions of Node. Currently tested using Node 11.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fervor",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A framework for building apps",
   "main": "lib/fervor",
   "author": "Parris Khachi",

--- a/src/cli/commands/migrate:latest.js
+++ b/src/cli/commands/migrate:latest.js
@@ -3,8 +3,8 @@ const path = require('path');
 
 module.exports = () => {
   if (process.env.DISABLE_DOT_ENV !== 'true') {
-    dotenv.config({ path: path.join(process.cwd(), '.env') });
     dotenv.config({ path: path.join(process.cwd(), '.env.personal') });
+    dotenv.config({ path: path.join(process.cwd(), '.env') });
   }
   // eslint-disable-next-line global-require
   const knex = require('../../config/knex');

--- a/src/cli/commands/migrate:rollback.js
+++ b/src/cli/commands/migrate:rollback.js
@@ -3,8 +3,8 @@ const path = require('path');
 
 module.exports = () => {
   if (process.env.DISABLE_DOT_ENV !== 'true') {
-    dotenv.config({ path: path.join(process.cwd(), '.env') });
     dotenv.config({ path: path.join(process.cwd(), '.env.personal') });
+    dotenv.config({ path: path.join(process.cwd(), '.env') });
   }
   // eslint-disable-next-line global-require
   const knex = require('../../config/knex');

--- a/src/cli/commands/start.js
+++ b/src/cli/commands/start.js
@@ -9,8 +9,8 @@ module.exports = () => {
   const routes = require(`${process.cwd()}/build/urls`).default;
 
   if (process.env.DISABLE_DOT_ENV !== 'true') {
-    dotenv.config({ path: path.join(process.cwd(), '.env') });
     dotenv.config({ path: path.join(process.cwd(), '.env.personal') });
+    dotenv.config({ path: path.join(process.cwd(), '.env') });
   }
 
   return startApp({

--- a/src/cli/commands/startBackendOnly.js
+++ b/src/cli/commands/startBackendOnly.js
@@ -9,12 +9,14 @@ module.exports = (args) => {
   // eslint-disable-next-line global-require, import/no-dynamic-require
   const routes = require(`${process.cwd()}/build/urls`).default;
 
-  if (args._[1]) {
-    dotenv.config({ path: path.join(process.cwd(), args._[1], '.env') });
-    dotenv.config({ path: path.join(process.cwd(), args._[1], '.env.personal') });
-  } else {
-    dotenv.config({ path: path.join(process.cwd(), '.env') });
-    dotenv.config({ path: path.join(process.cwd(), '.env.personal') });
+  if (process.env.DISABLE_DOT_ENV !== 'true') {
+    if (args._[1]) {
+      dotenv.config({ path: path.join(process.cwd(), args._[1], '.env.personal') });
+      dotenv.config({ path: path.join(process.cwd(), args._[1], '.env') });
+    } else {
+      dotenv.config({ path: path.join(process.cwd(), '.env.personal') });
+      dotenv.config({ path: path.join(process.cwd(), '.env') });
+    }
   }
 
   const port = process.env.PORT || 3000;

--- a/src/cli/commands/startDev.js
+++ b/src/cli/commands/startDev.js
@@ -13,13 +13,17 @@ module.exports = (args) => {
   if (args._[1]) {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     watcher = chokidar.watch(`${process.cwd()}/${args._[1]}`);
-    dotenv.config({ path: path.join(process.cwd(), args._[1], '.env') });
-    dotenv.config({ path: path.join(process.cwd(), args._[1], '.env.personal') });
+    if (process.env.DISABLE_DOT_ENV !== 'true') {
+      dotenv.config({ path: path.join(process.cwd(), args._[1], '.env.personal') });
+      dotenv.config({ path: path.join(process.cwd(), args._[1], '.env') });
+    }
   } else {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     watcher = chokidar.watch(`${process.cwd()}`);
-    dotenv.config({ path: path.join(process.cwd(), '.env') });
-    dotenv.config({ path: path.join(process.cwd(), '.env.personal') });
+    if (process.env.DISABLE_DOT_ENV !== 'true') {
+      dotenv.config({ path: path.join(process.cwd(), '.env.personal') });
+      dotenv.config({ path: path.join(process.cwd(), '.env') });
+    }
   }
 
   watcher.on('ready', () => {

--- a/src/cli/commands/startDevBackendOnly.js
+++ b/src/cli/commands/startDevBackendOnly.js
@@ -13,13 +13,17 @@ module.exports = (args) => {
   if (args._[1]) {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     watcher = chokidar.watch(`${process.cwd()}/${args._[1]}`);
-    dotenv.config({ path: path.join(process.cwd(), args._[1], '.env') });
-    dotenv.config({ path: path.join(process.cwd(), args._[1], '.env.personal') });
+    if (process.env.DISABLE_DOT_ENV !== 'true') {
+      dotenv.config({ path: path.join(process.cwd(), args._[1], '.env.personal') });
+      dotenv.config({ path: path.join(process.cwd(), args._[1], '.env') });
+    }
   } else {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     watcher = chokidar.watch(`${process.cwd()}`);
-    dotenv.config({ path: path.join(process.cwd(), '.env') });
-    dotenv.config({ path: path.join(process.cwd(), '.env.personal') });
+    if (process.env.DISABLE_DOT_ENV !== 'true') {
+      dotenv.config({ path: path.join(process.cwd(), '.env.personal') });
+      dotenv.config({ path: path.join(process.cwd(), '.env') });
+    }
   }
 
   watcher.on('ready', () => {

--- a/src/config/webpack.prod.js
+++ b/src/config/webpack.prod.js
@@ -5,6 +5,7 @@ require('@babel/register')(require('./babelrcHelper').default(true, false));
 const fs = require('fs');
 const path = require('path');
 const autoprefixer = require('autoprefixer');
+const dotenv = require('dotenv');
 const MiniCSSExtractPlugin = require('mini-css-extract-plugin');
 const globToRegExp = require('glob-to-regexp');
 const flexbugs = require('postcss-flexbugs-fixes');
@@ -17,6 +18,11 @@ const hasConfig = require('../shared/utils/hasConfig');
 const hasClientResolvers = require('../shared/utils/hasClientResolvers');
 const ChunkManifestPlugin = require('./ChunkManifestPlugin');
 const clientSideBabelConfig = require('./babelrcHelper').default(false, process.cwd(), true);
+
+if (process.env.DISABLE_DOT_ENV !== 'true') {
+  dotenv.config({ path: path.join(process.cwd(), '.env.personal') });
+  dotenv.config({ path: path.join(process.cwd(), '.env') });
+}
 
 const buildDir = path.join(process.cwd(), 'build');
 


### PR DESCRIPTION
.env.personal should get loaded first so it takes prescidence. In
addition, let's preserve the DISABLE_DOT_ENV flag and make sure it gets
called during the webpack build process.